### PR TITLE
multiprocessing.Queue has no `task_done()`

### DIFF
--- a/cluster/matrix.py
+++ b/cluster/matrix.py
@@ -58,10 +58,8 @@ class Matrix(object):
         for task in iter(self.task_queue.get, 'STOP'):
             col_index, item, item2 = task
             result = (col_index, self.combinfunc(item, item2))
-            self.task_queue.task_done()
             self.done_queue.put(result)
             tasks_completed += 1
-        self.task_queue.task_done()
         logger.info("Worker %s performed %s tasks",
                     current_process().name,
                     tasks_completed)
@@ -117,7 +115,6 @@ class Matrix(object):
                     # blocking operation)
                     if num_tasks_queued > num_processes:
                         col_index, result = self.done_queue.get()
-                        self.done_queue.task_done()
                         row[col_index] = result
                         num_tasks_completed += 1
                 else:
@@ -136,7 +133,6 @@ class Matrix(object):
                 # Grab the remaining worker task results
                 while num_tasks_completed < num_tasks_queued:
                     col_index, result = self.done_queue.get()
-                    self.done_queue.task_done()
                     row[col_index] = result
                     num_tasks_completed += 1
 


### PR DESCRIPTION
See https://docs.python.org/2/library/multiprocessing.html#pipes-and-queues

Specifically:

"The Queue, multiprocessing.queues.SimpleQueue and JoinableQueue types are multi-producer, multi-consumer FIFO queues modelled on the Queue.Queue class in the standard library. They differ in that Queue lacks the task_done() and join() methods introduced into Python 2.5’s Queue.Queue class."
