### PR TITLE
Changes intended to assist with investigation of issue #28 (possibly also issue #23)

### DIFF
--- a/cluster/test/test_hierarchical.py
+++ b/cluster/test/test_hierarchical.py
@@ -231,12 +231,42 @@ class HClusterTuplesTestCase(Py23TestCase):
         result = cl.getlevel(40)
         self.assertIsNotNone(result)
 
+class Issue28TestCase(Py23TestCase):
+    '''
+    Test case to cover the case where the data consist
+    of dictionary keys, and the distance function executes 
+    on the values these keys are associated with in the
+    dictionary, rather than the keys themselves.
 
+    Behaviour for this test case differs between Python2.7
+    and Python3.5: on 2.7 the test behaves as expected, 
+
+    See Github issue #28.
+    '''
+
+    def testIssue28(self):
+        "Issue28 (Hierarchical Clustering)"
+
+        points1D = {
+            'p4' : 5, 'p2' : 6, 'p7' : 10,
+            'p9' : 120, 'p10' : 121, 'p11' : 119,
+        }
+
+        distance_func = lambda a,b : abs(points1D[a]-points1D[b])
+        cl = HierarchicalClustering(list(points1D.keys()), distance_func)
+        result = cl.getlevel(20)
+        self.assertIsNotNone(result)
+    
 if __name__ == '__main__':
+
+    import logging
+
     suite = unittest.TestSuite((
         unittest.makeSuite(HClusterIntegerTestCase),
         unittest.makeSuite(HClusterSmallListTestCase),
         unittest.makeSuite(HClusterStringTestCase),
+        unittest.makeSuite(Issue28TestCase),
     ))
 
+    logging.basicConfig(level=logging.DEBUG)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/cluster/test/test_linkage.py
+++ b/cluster/test/test_linkage.py
@@ -29,3 +29,14 @@ class LinkageMethods(unittest.TestCase):
         result = average(self.set_a, self.set_b, self.dist)
         expected = 22.5
         self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+
+    import logging
+
+    suite = unittest.TestSuite((
+        unittest.makeSuite(LinkageMethods),
+    ))
+
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
I have added an extra test class to hierarchical_test.py which includes a set of data which illustrates the difference in behaviour between Python2.7 and Python3.5 which caused me to raise this issue.

From analysis of log files, I believe the point at which the behaviour of this test under the two Python versions begins to diverge in the python-cluster 1.4.1 code is the following four lines in matrix.py:
```
                    if not hasattr(item, '__iter__') or isinstance(item, tuple):
                        item = [item]
                    if not hasattr(item2, '__iter__') or isinstance(item2, tuple):
                        item2 = [item2]

```

I've replaced these four lines with a single function, invoked twice, which logs the name of type of the original item and the name of the type it is converted two.  From these log messages, I'm fairly certain that the problem is caused by the fact that Python2.7 (which works) encapsulates any item which is of type str as a list containing that str, whereas Python3.5 (which does not work) passes the str object on unchanged, with the result that later logic unpacks the string one character at a time instead of handling it as a whole.

I think the change in behaviour here may also be related to issue #23 (based on exhuma's comment on that issue dated 15 May 2017.

I will continue to investigate this issue when I get time and will cancel this PR and issue a new one if I feel I have a robust fix.