### PR TITLE
Proposed fix for issue #28

### DIFF
--- a/cluster/matrix.py
+++ b/cluster/matrix.py
@@ -31,18 +31,30 @@ def _encapsulate_item_for_combinfunc(item):
     before the invocation of combinfunc.
         if not hasattr(item, '__iter__') or isinstance(item, tuple):
             item = [item]
-    Logging has been added to the original two lines
-    and shows that the behaviour of this snippet
+    Logging was added to the original two lines
+    and shows that the outcome of this snippet
     has changed between Python2.7 and Python3.5.
+    This logging showed that the difference in 
+    outcome consisted of the handling of the builtin
+    str class, which was encapsulated into a list in
+    Python2.7 but returned naked in Python3.5.
+    Adding a test for this specific class to the 
+    set of conditions appears to give correct behaviour
+    under both versions.
     """
     encapsulated_item = None
-    if not hasattr(item, '__iter__') or isinstance(item, tuple):
+    if  (
+        not hasattr(item, '__iter__') or
+        isinstance(item, tuple) or
+        isinstance(item, str)
+    ):
         encapsulated_item = [item]
     else:
         encapsulated_item = item
     logging.debug(
         "item class:%s encapsulated as:%s ",
-        item.__class__, encapsulated_item.__class__
+        item.__class__.__name__, 
+        encapsulated_item.__class__.__name__
     )
     return encapsulated_item
 

--- a/cluster/test/test_hierarchical.py
+++ b/cluster/test/test_hierarchical.py
@@ -231,12 +231,42 @@ class HClusterTuplesTestCase(Py23TestCase):
         result = cl.getlevel(40)
         self.assertIsNotNone(result)
 
+class Issue28TestCase(Py23TestCase):
+    '''
+    Test case to cover the case where the data consist
+    of dictionary keys, and the distance function executes 
+    on the values these keys are associated with in the
+    dictionary, rather than the keys themselves.
 
+    Behaviour for this test case differs between Python2.7
+    and Python3.5: on 2.7 the test behaves as expected, 
+
+    See Github issue #28.
+    '''
+
+    def testIssue28(self):
+        "Issue28 (Hierarchical Clustering)"
+
+        points1D = {
+            'p4' : 5, 'p2' : 6, 'p7' : 10,
+            'p9' : 120, 'p10' : 121, 'p11' : 119,
+        }
+
+        distance_func = lambda a,b : abs(points1D[a]-points1D[b])
+        cl = HierarchicalClustering(list(points1D.keys()), distance_func)
+        result = cl.getlevel(20)
+        self.assertIsNotNone(result)
+    
 if __name__ == '__main__':
+
+    import logging
+
     suite = unittest.TestSuite((
         unittest.makeSuite(HClusterIntegerTestCase),
         unittest.makeSuite(HClusterSmallListTestCase),
         unittest.makeSuite(HClusterStringTestCase),
+        unittest.makeSuite(Issue28TestCase),
     ))
 
+    logging.basicConfig(level=logging.DEBUG)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/cluster/test/test_linkage.py
+++ b/cluster/test/test_linkage.py
@@ -29,3 +29,14 @@ class LinkageMethods(unittest.TestCase):
         result = average(self.set_a, self.set_b, self.dist)
         expected = 22.5
         self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+
+    import logging
+
+    suite = unittest.TestSuite((
+        unittest.makeSuite(LinkageMethods),
+    ))
+
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Please consider the attached commits, which I believe address issue #28, at least in relation to the specific problem I was having in which Python3.5 failed to perform clustering on a collection which consisted of keys of type str which were used to look up GPS coordinates in an external container for the calculation of the distance function.

As part of this branch, I have added a test class for this specific case.  I also broke out an expression which was repeated inline in file matrix.py into a function, and instrumented it with a log message which helped me work out what was going on.  I am not certain whether this change would have significant negative performance impact on large datasets.

I suspect there are other possible key types which might have the same problem (e.g. bytes etc).  I'll leave it to the parent app maintainers whether to revert to remove the log message and/or revert to the original inline form.

Thanks again to the maintainers for making this valuable library available.